### PR TITLE
#1795 Give the decoder more time to analyze

### DIFF
--- a/src/media/media_decoder.cpp
+++ b/src/media/media_decoder.cpp
@@ -579,14 +579,19 @@ MediaDecoder::setupStream()
         JAMI_DBG() << "Using framerate emulation";
     startTime_ = av_gettime(); // used to set pts after decoding, and for rate emulation
 
+    AVDictionary* options = nullptr;
+    av_dict_set(&options, "analyzeduration", std::to_string(90 * 1000000).c_str(), 0); // wait 30s, instead of default 5
+    av_dict_set(&options, "probesize", std::to_string(5000 * 1000000).c_str(), 0); // instead of default 5
+
 #ifdef RING_ACCEL
     if (!accel_) {
         JAMI_WARN("Not using hardware decoding for %s", avcodec_get_name(decoderCtx_->codec_id));
-        ret = avcodec_open2(decoderCtx_, inputDecoder_, nullptr);
+        ret = avcodec_open2(decoderCtx_, inputDecoder_, &options);
     }
 #else
-    ret = avcodec_open2(decoderCtx_, inputDecoder_, nullptr);
+    ret = avcodec_open2(decoderCtx_, inputDecoder_, &options);
 #endif
+    av_dict_free(&options);
     if (ret < 0) {
         JAMI_ERR() << "Unable to open codec: " << libav_utils::getError(ret);
         return -1;


### PR DESCRIPTION
Works 10 out of 10 times. Still don't know the exact root cause, but at least it's an ok workaround.
Upstream: https://git.jami.net/savoirfairelinux/jami-client-android/-/issues/1795